### PR TITLE
OAuth pipeline of Identity Framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 os: linux		
 dist: trusty
-mono: none
+mono: latest
 sudo: required
 dotnet: 1.0.0-preview2-1-003177
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: csharp
 os: linux		
-dist: trusty		
+dist: trusty
+mono: none
 sudo: required
 dotnet: 1.0.0-preview2-1-003177
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: csharp
+os: linux		
+dist: trusty		
+sudo: required
+dotnet: 1.0.0-preview2-1-003177
+install:
+- dotnet restore
+before_script:
+- sh -e /etc/init.d/xvfb start
+solution: "./Promact.OAuth.Client/Promact.OAuth.Client.sln"
+notifications:
+  email:
+    on_success: change
+    on_failure: always
+script:
+- dotnet build ./Promact.OAuth.Client/src/Promact.OAuth.Client.Tests -c Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ notifications:
     on_success: change
     on_failure: always
 script:
-- dotnet build ./Promact.OAuth.Client/src/Promact.OAuth.Client.Tests -c Release
+- dotnet build ./Promact.OAuth.Client/src/Promact.OAuth.Client -c Release

--- a/Promact.OAuth.Client/global.json
+++ b/Promact.OAuth.Client/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "projects": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-preview2-003131"
+    "version": "1.0.0-preview2-1-003177"
   }
 }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/project.json
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "testRunner": "xunit",
   "dependencies": {
-    "Microsoft.Extensions.DependencyInjection": "1.2.0-preview1-22929",
+    "Microsoft.Extensions.DependencyInjection": "1.1.0",
     "Moq": "4.6.38-alpha",
     "Promact.OAuth.Client": "1.0.0-*",
     "xunit": "2.2.0-beta2-build3300",

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/project.json
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/project.json
@@ -1,11 +1,12 @@
 {
   "version": "1.0.0-*",
   "testRunner": "xunit",
-  "dependencies": {    
+  "dependencies": {
+    "Microsoft.Extensions.DependencyInjection": "1.2.0-preview1-22929",
     "Moq": "4.6.38-alpha",
     "Promact.OAuth.Client": "1.0.0-*",
-    "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "xunit": "2.2.0-beta5-build3474"
+    "xunit": "2.2.0-beta2-build3300",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
 
   "frameworks": {
@@ -22,5 +23,8 @@
         }
       }
     }
+  },
+  "runtimes": {
+    "win10-x64": {}
   }
 }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/project.json
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/project.json
@@ -1,12 +1,11 @@
 {
   "version": "1.0.0-*",
   "testRunner": "xunit",
-  "dependencies": {
-    "Microsoft.Extensions.DependencyInjection": "1.2.0-preview1-22929",
+  "dependencies": {    
     "Moq": "4.6.38-alpha",
     "Promact.OAuth.Client": "1.0.0-*",
-    "xunit": "2.2.0-beta2-build3300",
-    "dotnet-test-xunit": "2.2.0-preview2-build1029"
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
+    "xunit": "2.2.0-beta5-build3474"
   },
 
   "frameworks": {
@@ -23,8 +22,5 @@
         }
       }
     }
-  },
-  "runtimes": {
-    "win10-x64": {}
   }
 }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/DomainModel/PromactAuthenticationOptions.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/DomainModel/PromactAuthenticationOptions.cs
@@ -1,0 +1,52 @@
+﻿#if NET461
+using Microsoft.Owin.Security.OpenIdConnect;
+#endif
+using System.Collections.Generic;
+
+namespace Promact.OAuth.Client.DomainModel
+{
+    /// <summary>
+    /// Configuration Option PromactAuthentication
+    /// </summary>
+    public class PromactAuthenticationOptions
+    {
+        /// <summary>
+        /// Constuctor of PromactAuthenticationOptions
+        /// </summary>
+        public PromactAuthenticationOptions()
+        {
+            AllowedScopes = new List<Scopes>();
+        }
+        /// <summary>
+        /// Promact-Oauth's Client Id
+        /// </summary>
+        public string ClientId { get; set; }
+        /// <summary>
+        /// Promact-Oauth's Client Secret
+        /// </summary>
+        public string ClientSecret { get; set; }
+        /// <summary>
+        /// Promact-Oauth's Authority Url
+        /// </summary>
+        public string Authority { get; set; }
+        /// <summary>
+        /// Promact-Oauth's Logout Url
+        /// </summary>
+        public string LogoutUrl { get; set; }
+        /// <summary>
+        /// Allowed scope for Promact-Oauth's App
+        /// </summary>
+        public List<Scopes> AllowedScopes { get; }
+#if NET461
+        /// <summary>
+        /// Redirect Url for Promact-Oauth's App
+        /// </summary>
+        public string RedirectUrl { get; set; }
+        /// <summary>
+        /// Gets or sets the Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationNotifications
+        /// to notify when processing OpenIdConnect messages.
+        /// </summary>
+        public OpenIdConnectAuthenticationNotifications Notifications { get; set; }
+#endif
+    }
+}

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/DomainModel/Scopes.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/DomainModel/Scopes.cs
@@ -1,0 +1,37 @@
+﻿namespace Promact.OAuth.Client.DomainModel
+{
+    /// <summary>
+    /// Promact OAuth's Allowed scopes
+    /// </summary>
+    public enum Scopes
+    {
+        /// <summary>
+        /// Scope email
+        /// </summary>
+        email,
+        /// <summary>
+        /// Scope openid
+        /// </summary>
+        openid,
+        /// <summary>
+        /// Scope profile
+        /// </summary>
+        profile,
+        /// <summary>
+        /// Scope slack user Id
+        /// </summary>
+        slack_user_id,
+        /// <summary>
+        /// Scope user read
+        /// </summary>
+        user_read,
+        /// <summary>
+        /// Scope project read
+        /// </summary>
+        project_read,
+        /// <summary>
+        /// Scope offline_access
+        /// </summary>
+        offline_access
+    }
+}

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Middleware/AuthenticationMiddleware.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Middleware/AuthenticationMiddleware.cs
@@ -24,6 +24,7 @@ namespace Promact.OAuth.Client.Middleware
         /// <returns>Then updated Owin.IAppBuilder</returns>
         public static IAppBuilder UsePromactAuthentication(this IAppBuilder app, PromactAuthenticationOptions options)
         {
+            var allowedScopes = string.Join(" ", options.AllowedScopes);
             IStringConstant _stringConstant = new StringConstant();
             var openIdConnectAuthenticationOptions = new OpenIdConnectAuthenticationOptions();
             openIdConnectAuthenticationOptions.Authority = options.Authority;
@@ -31,7 +32,7 @@ namespace Promact.OAuth.Client.Middleware
             openIdConnectAuthenticationOptions.ClientSecret = options.ClientSecret;
             openIdConnectAuthenticationOptions.RedirectUri = options.RedirectUrl;
             openIdConnectAuthenticationOptions.ResponseType = _stringConstant.ResponseTypeCodeAndIdToken;
-            openIdConnectAuthenticationOptions.Scope = "openid offline_access email profile slack_user_id user_read project_read";
+            openIdConnectAuthenticationOptions.Scope = allowedScopes;
             openIdConnectAuthenticationOptions.SignInAsAuthenticationType = _stringConstant.SignInSchemeCookies;
             openIdConnectAuthenticationOptions.AuthenticationType = _stringConstant.OIDCAuthenticationScheme;
             openIdConnectAuthenticationOptions.PostLogoutRedirectUri = options.LogoutUrl;

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Middleware/AuthenticationMiddleware.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Middleware/AuthenticationMiddleware.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Promact.OAuth.Client.Util.StringConstant;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Promact.OAuth.Client.DomainModel;
+#if NET461
+using Owin;
+using Microsoft.Owin.Security.OpenIdConnect;
+#endif
+
+namespace Promact.OAuth.Client.Middleware
+{
+    /// <summary>
+    /// Promact Authentication Middleware
+    /// </summary>
+    public static class AuthenticationMiddleware
+    {
+#if NET461
+        /// <summary>
+        /// Adds the Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationMiddleware
+        /// into the OWIN runtime for promact-oauth-server
+        /// </summary>
+        /// <param name="app">Owin.IAppBuilder</param>
+        /// <param name="options">Configuration Option PromactAuthentication</param>
+        /// <returns>Then updated Owin.IAppBuilder</returns>
+        public static IAppBuilder UsePromactAuthentication(this IAppBuilder app, PromactAuthenticationOptions options)
+        {
+            IStringConstant _stringConstant = new StringConstant();
+            var openIdConnectAuthenticationOptions = new OpenIdConnectAuthenticationOptions();
+            openIdConnectAuthenticationOptions.Authority = options.Authority;
+            openIdConnectAuthenticationOptions.ClientId = options.ClientId;
+            openIdConnectAuthenticationOptions.ClientSecret = options.ClientSecret;
+            openIdConnectAuthenticationOptions.RedirectUri = options.RedirectUrl;
+            openIdConnectAuthenticationOptions.ResponseType = _stringConstant.ResponseTypeCodeAndIdToken;
+            openIdConnectAuthenticationOptions.Scope = "openid offline_access email profile slack_user_id user_read project_read";
+            openIdConnectAuthenticationOptions.SignInAsAuthenticationType = _stringConstant.SignInSchemeCookies;
+            openIdConnectAuthenticationOptions.AuthenticationType = _stringConstant.OIDCAuthenticationScheme;
+            openIdConnectAuthenticationOptions.PostLogoutRedirectUri = options.LogoutUrl;
+            openIdConnectAuthenticationOptions.UseTokenLifetime = true;
+            openIdConnectAuthenticationOptions.Notifications = options.Notifications;
+            return app.UseOpenIdConnectAuthentication(openIdConnectAuthenticationOptions);
+        }
+#else
+        /// <summary>
+        /// Adds the Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectMiddleware
+        /// middleware to the specified Microsoft.AspNetCore.Builder.IApplicationBuilder,
+        /// which enables OpenID Connect authentication capabilities from promact-oauth-server.
+        /// </summary>
+        /// <param name="app">Microsoft.AspNetCore.Builder.IApplicationBuilder</param>
+        /// <param name="options">Configuration Option PromactAuthentication</param>
+        /// <returns>The updated Microsoft.AspNetCore.Builder.IApplicationBuilder</returns>
+        public static IApplicationBuilder UsePromactAuthentication(this IApplicationBuilder app, PromactAuthenticationOptions options)
+        {
+            var openIdConnecOptions = new OpenIdConnectOptions();
+            IStringConstant _stringConstant = new StringConstant();
+            foreach (var scope in options.AllowedScopes)
+            {
+                openIdConnecOptions.Scope.Add(scope.ToString());
+            }
+            openIdConnecOptions.AuthenticationScheme = _stringConstant.OIDCAuthenticationScheme;
+            openIdConnecOptions.SignInScheme = _stringConstant.SignInSchemeCookies;
+            openIdConnecOptions.Authority = options.Authority;
+            openIdConnecOptions.RequireHttpsMetadata = false;
+            openIdConnecOptions.ClientId = options.ClientId;
+            openIdConnecOptions.ClientSecret = options.ClientSecret;
+            openIdConnecOptions.ResponseType = _stringConstant.ResponseTypeCodeAndIdToken;
+            openIdConnecOptions.GetClaimsFromUserInfoEndpoint = true;
+            openIdConnecOptions.SaveTokens = true;
+            openIdConnecOptions.AutomaticAuthenticate = true;
+            openIdConnecOptions.AutomaticChallenge = true;
+            openIdConnecOptions.PostLogoutRedirectUri = options.LogoutUrl;
+            openIdConnecOptions.UseTokenLifetime = true;
+            openIdConnecOptions.AuthenticationMethod = OpenIdConnectRedirectBehavior.RedirectGet;
+            return app.UseOpenIdConnectAuthentication(openIdConnecOptions);
+        }
+#endif
+    }
+}

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/IStringConstant.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/IStringConstant.cs
@@ -124,5 +124,22 @@
         /// </summary>
         string EmailRandomValueForTest { get; }
         #endregion
+
+        #region Middleware Pipeline
+        /// <summary>
+        /// OIDC authentication-scheme
+        /// </summary>
+        string OIDCAuthenticationScheme { get; }
+
+        /// <summary>
+        /// SignIn-scheme cookies
+        /// </summary>
+        string SignInSchemeCookies { get; }
+
+        /// <summary>
+        /// Response type code, id_token and token
+        /// </summary>
+        string ResponseTypeCodeAndIdToken { get; }
+        #endregion
     }
 }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/StringConstant.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/StringConstant.cs
@@ -309,5 +309,40 @@
             }
         }
         #endregion
+
+        #region Middleware Pipeline
+        /// <summary>
+        /// OIDC authentication-scheme
+        /// </summary>
+        public string OIDCAuthenticationScheme
+        {
+            get
+            {
+                return "oidc";
+            }
+        }
+
+        /// <summary>
+        /// SignIn-scheme cookies
+        /// </summary>
+        public string SignInSchemeCookies
+        {
+            get
+            {
+                return "Cookies";
+            }
+        }
+
+        /// <summary>
+        /// Response type code, id_token and token
+        /// </summary>
+        public string ResponseTypeCodeAndIdToken
+        {
+            get
+            {
+                return "code id_token token";
+            }
+        }
+        #endregion
     }
 }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/project.json
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/project.json
@@ -1,14 +1,22 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
+    "Microsoft.AspNetCore.Authentication.OpenIdConnect": "1.1.0",
     "NETStandard.Library": "1.6.1",
-    "Newtonsoft.Json": "9.0.2-beta2",
-    "System.Net.Security": "4.3.0"
+    "Newtonsoft.Json": "9.0.2-beta1",
+    "System.Net.Security": "4.0.0"
   },
   "frameworks": {
     "netstandard1.6": {
       "imports": "dnxcore50"
-    }    
+    },
+    "net461": {
+      "dependencies": {
+        "Microsoft.Owin.Security.Cookies": "3.0.1",
+        "Microsoft.Owin.Security.OpenIdConnect": "3.0.1",
+        "Owin": "1.0.0"
+      }
+    }
   },
   "buildOptions": {
     "xmlDoc": true

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/project.json
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/project.json
@@ -1,7 +1,8 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
+    "Microsoft.AspNetCore.Authentication.OpenIdConnect": "1.1.0",
+    "NETStandard.Library": "1.6.1",
     "Newtonsoft.Json": "9.0.2-beta1",
     "System.Net.Security": "4.0.0"
   },
@@ -10,6 +11,11 @@
       "imports": "dnxcore50"
     },
     "net461": {
+      "dependencies": {
+        "Microsoft.Owin.Security.Cookies": "3.0.1",
+        "Microsoft.Owin.Security.OpenIdConnect": "3.0.1",
+        "Owin": "1.0.0"
+      }
     }
   },
   "buildOptions": {

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/project.json
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/project.json
@@ -9,14 +9,15 @@
   "frameworks": {
     "netstandard1.6": {
       "imports": "dnxcore50"
-    },
-    "net461": {
-      "dependencies": {
-        "Microsoft.Owin.Security.Cookies": "3.0.1",
-        "Microsoft.Owin.Security.OpenIdConnect": "3.0.1",
-        "Owin": "1.0.0"
-      }
     }
+    //},
+    //"net461": {
+    //  "dependencies": {
+    //    "Microsoft.Owin.Security.Cookies": "3.0.1",
+    //    "Microsoft.Owin.Security.OpenIdConnect": "3.0.1",
+    //    "Owin": "1.0.0"
+    //  }
+    //}
   },
   "buildOptions": {
     "xmlDoc": true

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/project.json
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/project.json
@@ -3,21 +3,20 @@
   "dependencies": {
     "Microsoft.AspNetCore.Authentication.OpenIdConnect": "1.1.0",
     "NETStandard.Library": "1.6.1",
-    "Newtonsoft.Json": "9.0.2-beta1",
-    "System.Net.Security": "4.0.0"
+    "Newtonsoft.Json": "9.0.2-beta2",
+    "System.Net.Security": "4.3.0"
   },
   "frameworks": {
     "netstandard1.6": {
       "imports": "dnxcore50"
+    },
+    "net461": {
+      "dependencies": {
+        "Microsoft.Owin.Security.Cookies": "3.0.1",
+        "Microsoft.Owin.Security.OpenIdConnect": "3.0.1",
+        "Owin": "1.0.0"
+      }
     }
-    //},
-    //"net461": {
-    //  "dependencies": {
-    //    "Microsoft.Owin.Security.Cookies": "3.0.1",
-    //    "Microsoft.Owin.Security.OpenIdConnect": "3.0.1",
-    //    "Owin": "1.0.0"
-    //  }
-    //}
   },
   "buildOptions": {
     "xmlDoc": true

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/project.json
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/project.json
@@ -1,16 +1,14 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "Newtonsoft.Json": "9.0.2-beta1",
-    "System.Net.Security": "4.0.0"
+    "NETStandard.Library": "1.6.1",
+    "Newtonsoft.Json": "9.0.2-beta2",
+    "System.Net.Security": "4.3.0"
   },
   "frameworks": {
     "netstandard1.6": {
       "imports": "dnxcore50"
-    },
-    "net461": {
-    }
+    }    
   },
   "buildOptions": {
     "xmlDoc": true

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # oauth-client
+
+[![Build Status](https://travis-ci.org/Promact/oauth-client.svg?branch=dev)](https://travis-ci.org/Promact/oauth-client)
+
 Client library for Promact OAuth server


### PR DESCRIPTION
Fixes - #3 

**1. PromactAuthenticationOptions.cs** - Configuration Option class
**2. Scopes.cs** - enum of allowed scopes
**3. AuthenticationMiddleware.cs** - middleware pipeline of multiple targets
**4. IStringConstant.cs** - added string constant for middleware pipelining -> OIDCAuthenticationScheme, SignInSchemeCookies and ResponseTypeCodeAndIdToken
**5. StringConstant.cs** - added string constant for middleware pipelining -> OIDCAuthenticationScheme, SignInSchemeCookies and ResponseTypeCodeAndIdToken
**6. project.json** - added new packages ->
Dependency for all:-
"Microsoft.AspNetCore.Authentication.OpenIdConnect": "1.1.0"
Dependency for NET461:-
"Microsoft.Owin.Security.Cookies": "3.0.1",
"Microsoft.Owin.Security.OpenIdConnect": "3.0.1",
"Owin": "1.0.0"