### PR TITLE
Integration Test

### DIFF
--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/IntegrationBaseProvider.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/IntegrationBaseProvider.cs
@@ -5,17 +5,22 @@ using Promact.OAuth.Client.Repository.User;
 using Promact.OAuth.Client.Util.StringConstant;
 using Promact.OAuth.Client.Util.HttpClientWrapper;
 using IdentityModel.Client;
+using Promact.OAuth.Client.DomainModel;
 
 namespace Promact.OAuth.Client.Test
 {
     public class IntegrationBaseProvider
-    { 
+    {
+        #region Variables
         public IServiceProvider serviceProvider { get; set; }
         private readonly TokenClient _client;
         public readonly TokenResponse _userScopeResponse;
         public readonly TokenResponse _projectScopeResponse;
         public readonly DiscoveryResponse _discoveryClient;
+        public readonly IStringConstant _stringConstant;
+        #endregion
 
+        #region Constructor
         public IntegrationBaseProvider()
         {
             var services = new ServiceCollection();
@@ -24,12 +29,15 @@ namespace Promact.OAuth.Client.Test
             services.AddScoped<IStringConstant, StringConstant>();
             services.AddScoped<IHttpClientService, HttpClientService>();
             serviceProvider = services.BuildServiceProvider();
-            var discovery = new DiscoveryClient("http://oauth.promactinfo.com/");
+            _stringConstant = serviceProvider.GetService<IStringConstant>();
+            var discovery = new DiscoveryClient(_stringConstant.PromactOAuthUrl);
             discovery.Policy.RequireHttps = false;
             _discoveryClient = discovery.GetAsync().Result;
-            _client = new TokenClient(_discoveryClient.TokenEndpoint, "OOKK4SVDYQ8XRUU", "icbbHra92LEzIS5AHE6NuuR0Qk20Oo");
-            _userScopeResponse = _client.RequestClientCredentialsAsync("user_read").Result;
-            _projectScopeResponse = _client.RequestClientCredentialsAsync("project_read").Result;
+            _client = new TokenClient(_discoveryClient.TokenEndpoint, _stringConstant.PromactOAuthClientId, 
+                _stringConstant.PromactOAuthClientSecret);
+            _userScopeResponse = _client.RequestClientCredentialsAsync(Scopes.user_read.ToString()).Result;
+            _projectScopeResponse = _client.RequestClientCredentialsAsync(Scopes.project_read.ToString()).Result;
         }
+        #endregion
     }
 }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/IntegrationBaseProvider.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/IntegrationBaseProvider.cs
@@ -9,7 +9,7 @@ using IdentityModel.Client;
 namespace Promact.OAuth.Client.Test
 {
     public class IntegrationBaseProvider
-    {
+    { 
         public IServiceProvider serviceProvider { get; set; }
         private readonly TokenClient _client;
         public readonly TokenResponse _userScopeResponse;

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/IntegrationBaseProvider.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/IntegrationBaseProvider.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Promact.OAuth.Client.Repository.Project;
+using Promact.OAuth.Client.Repository.User;
+using Promact.OAuth.Client.Util.StringConstant;
+using Promact.OAuth.Client.Util.HttpClientWrapper;
+using IdentityModel.Client;
+
+namespace Promact.OAuth.Client.Test
+{
+    public class IntegrationBaseProvider
+    {
+        public IServiceProvider serviceProvider { get; set; }
+        private readonly DiscoveryResponse _discovery;
+        private readonly TokenClient _client;
+        public readonly TokenResponse _userScopeResponse;
+        public readonly TokenResponse _projectScopeResponse;
+
+        public IntegrationBaseProvider()
+        {
+            var services = new ServiceCollection();
+            services.AddScoped<IProjectModule, ProjectModule>();
+            services.AddScoped<IUserModule, UserModule>();
+            services.AddScoped<IStringConstant, StringConstant>();
+            services.AddScoped<IHttpClientService, HttpClientService>();
+            serviceProvider = services.BuildServiceProvider();
+            _discovery = DiscoveryClient.GetAsync("http://localhost:35716/").Result;
+            _client = new TokenClient(_discovery.TokenEndpoint, "O1UGSJW6X4V16IY", "RtZIZVt7VyW11NiSKazAxvTZlOpjRf");
+            _userScopeResponse = _client.RequestClientCredentialsAsync("user_read").Result;
+            _projectScopeResponse = _client.RequestClientCredentialsAsync("project_read").Result;
+        }
+    }
+}

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/IntegrationBaseProvider.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/IntegrationBaseProvider.cs
@@ -11,10 +11,10 @@ namespace Promact.OAuth.Client.Test
     public class IntegrationBaseProvider
     {
         public IServiceProvider serviceProvider { get; set; }
-        private readonly DiscoveryResponse _discovery;
         private readonly TokenClient _client;
         public readonly TokenResponse _userScopeResponse;
         public readonly TokenResponse _projectScopeResponse;
+        public readonly DiscoveryResponse _discoveryClient;
 
         public IntegrationBaseProvider()
         {
@@ -24,8 +24,10 @@ namespace Promact.OAuth.Client.Test
             services.AddScoped<IStringConstant, StringConstant>();
             services.AddScoped<IHttpClientService, HttpClientService>();
             serviceProvider = services.BuildServiceProvider();
-            _discovery = DiscoveryClient.GetAsync("http://localhost:35716/").Result;
-            _client = new TokenClient(_discovery.TokenEndpoint, "O1UGSJW6X4V16IY", "RtZIZVt7VyW11NiSKazAxvTZlOpjRf");
+            var discovery = new DiscoveryClient("http://oauth.promactinfo.com/");
+            discovery.Policy.RequireHttps = false;
+            _discoveryClient = discovery.GetAsync().Result;
+            _client = new TokenClient(_discoveryClient.TokenEndpoint, "OOKK4SVDYQ8XRUU", "icbbHra92LEzIS5AHE6NuuR0Qk20Oo");
             _userScopeResponse = _client.RequestClientCredentialsAsync("user_read").Result;
             _projectScopeResponse = _client.RequestClientCredentialsAsync("project_read").Result;
         }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/ProjectModuleIntegrationTest.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/ProjectModuleIntegrationTest.cs
@@ -11,15 +11,21 @@ namespace Promact.OAuth.Client.Test
 {
     public class ProjectModuleIntegrationTest : IntegrationBaseProvider
     {
+        #region Private Variables
         private readonly IProjectModule _projectModule;
         private readonly IStringConstant _stringConstant;
+        #endregion
+
+        #region Constructor
         public ProjectModuleIntegrationTest() : base()
         {
             _projectModule = serviceProvider.GetService<IProjectModule>();
             _stringConstant = serviceProvider.GetService<IStringConstant>();
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:35716/";
+            PromactBaseUrl.PromactOAuthUrl = "http://oauth.promactinfo.com/";
         }
+        #endregion
 
+        #region Test cases
         /// <summary>
         /// Integration Test GetPromactProjectDetailsByGroupNameAsync
         /// </summary>
@@ -96,5 +102,6 @@ namespace Promact.OAuth.Client.Test
             _projectModule.GetPromactProjectDetailsByIdAsync(1000, _projectScopeResponse.AccessToken));
             Assert.NotNull(result.Message);
         }
+        #endregion
     }
 }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/ProjectModuleIntegrationTest.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/ProjectModuleIntegrationTest.cs
@@ -1,0 +1,100 @@
+﻿using System.Threading.Tasks;
+using Promact.OAuth.Client.Repository.Project;
+using Microsoft.Extensions.DependencyInjection;
+using Promact.OAuth.Client.Util.ExceptionHandler;
+using Promact.OAuth.Client.Util.StringConstant;
+using Xunit;
+using System.Net.Http;
+using Promact.OAuth.Client.Repository.BaseUrlSetUp;
+
+namespace Promact.OAuth.Client.Test
+{
+    public class ProjectModuleIntegrationTest : IntegrationBaseProvider
+    {
+        private readonly IProjectModule _projectModule;
+        private readonly IStringConstant _stringConstant;
+        public ProjectModuleIntegrationTest() : base()
+        {
+            _projectModule = serviceProvider.GetService<IProjectModule>();
+            _stringConstant = serviceProvider.GetService<IStringConstant>();
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:35716/";
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactProjectDetailsByGroupNameAsync
+        /// </summary>
+        [Fact]
+        public async Task GetPromactProjectDetailsByGroupNameAsync()
+        {
+            var result = await _projectModule.GetPromactProjectDetailsByGroupNameAsync("Slash-Command", _projectScopeResponse.AccessToken);
+            Assert.Equal(result.Id, 1);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactProjectDetailsByGroupNameAsync for HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactProjectDetailsByGroupNameAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(()=>
+            _projectModule.GetPromactProjectDetailsByGroupNameAsync("Slash-Command", _projectScopeResponse.AccessToken));
+            Assert.NotNull(result.Message);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactAllProjectsAsync
+        /// </summary>
+        [Fact]
+        public async Task GetPromactAllProjectsAsync()
+        {
+            var result = await _projectModule.GetPromactAllProjectsAsync(_projectScopeResponse.AccessToken);
+            Assert.NotEqual(result.Count, 0);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactAllProjectsAsync for HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactAllProjectsAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(()=>
+            _projectModule.GetPromactAllProjectsAsync(_projectScopeResponse.AccessToken));
+            Assert.NotNull(result.Message);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactProjectDetailsByIdAsync
+        /// </summary>
+        [Fact]
+        public async Task GetPromactProjectDetailsByIdAsync()
+        {
+            var result = await _projectModule.GetPromactProjectDetailsByIdAsync(1, _projectScopeResponse.AccessToken);
+            Assert.Equal(result.IsActive, true);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactProjectDetailsByIdAsync for ProjectNotFoundException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactProjectDetailsByIdAsyncProjectNotFoundException()
+        {
+            var result = await Assert.ThrowsAsync<ProjectNotFoundException>(()=>
+            _projectModule.GetPromactProjectDetailsByIdAsync(1000, _projectScopeResponse.AccessToken));
+            Assert.Equal(result.Message, _stringConstant.ProjectNotFoundException);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactProjectDetailsByIdAsync for HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactProjectDetailsByIdAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            _projectModule.GetPromactProjectDetailsByIdAsync(1000, _projectScopeResponse.AccessToken));
+            Assert.NotNull(result.Message);
+        }
+    }
+}

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/ProjectModuleIntegrationTest.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/ProjectModuleIntegrationTest.cs
@@ -2,7 +2,6 @@
 using Promact.OAuth.Client.Repository.Project;
 using Microsoft.Extensions.DependencyInjection;
 using Promact.OAuth.Client.Util.ExceptionHandler;
-using Promact.OAuth.Client.Util.StringConstant;
 using Xunit;
 using System.Net.Http;
 using Promact.OAuth.Client.Repository.BaseUrlSetUp;
@@ -13,15 +12,13 @@ namespace Promact.OAuth.Client.Test
     {
         #region Private Variables
         private readonly IProjectModule _projectModule;
-        private readonly IStringConstant _stringConstant;
         #endregion
 
         #region Constructor
         public ProjectModuleIntegrationTest() : base()
         {
             _projectModule = serviceProvider.GetService<IProjectModule>();
-            _stringConstant = serviceProvider.GetService<IStringConstant>();
-            PromactBaseUrl.PromactOAuthUrl = "http://oauth.promactinfo.com/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.PromactOAuthUrl;
         }
         #endregion
 
@@ -32,7 +29,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactProjectDetailsByGroupNameAsync()
         {
-            var result = await _projectModule.GetPromactProjectDetailsByGroupNameAsync("Slash-Command", _projectScopeResponse.AccessToken);
+            var result = await _projectModule.GetPromactProjectDetailsByGroupNameAsync(_stringConstant.ProjectGroupNameForTest, 
+                _projectScopeResponse.AccessToken);
             Assert.Equal(result.Id, 1);
         }
 
@@ -42,9 +40,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactProjectDetailsByGroupNameAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(()=>
-            _projectModule.GetPromactProjectDetailsByGroupNameAsync("Slash-Command", _projectScopeResponse.AccessToken));
+            _projectModule.GetPromactProjectDetailsByGroupNameAsync(_stringConstant.ProjectGroupNameForTest, 
+            _projectScopeResponse.AccessToken));
             Assert.NotNull(result.Message);
         }
 
@@ -64,7 +63,7 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactAllProjectsAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(()=>
             _projectModule.GetPromactAllProjectsAsync(_projectScopeResponse.AccessToken));
             Assert.NotNull(result.Message);
@@ -97,7 +96,7 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactProjectDetailsByIdAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
             _projectModule.GetPromactProjectDetailsByIdAsync(1000, _projectScopeResponse.AccessToken));
             Assert.NotNull(result.Message);

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/ProjectModuleTest.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/ProjectModuleTest.cs
@@ -235,7 +235,6 @@ namespace Promact.OAuth.Client.Test
             user.IsActive = true;
             user.NumberOfCasualLeave = 9;
             user.NumberOfSickLeave = 4;
-            user.SlackUserId = _stringConstant.SlackUserIdForTest;
             user.UserName = _stringConstant.EmailRandomValueForTest;
             userList.Add(user);
             project.CreatedDate = DateTime.UtcNow;

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/UserModuleIntegrationTest.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/UserModuleIntegrationTest.cs
@@ -62,7 +62,7 @@ namespace Promact.OAuth.Client.Test
         /// <summary>
         /// Integration Test GetListOfPromactTeamLeaderByUsersSlackIdAsync
         /// </summary>
-        //[Fact]
+        [Fact]
         public async Task GetListOfPromactTeamLeaderByUsersSlackIdAsync()
         {
             var result = await _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync("9cdc7982-25b9-45a4-afdc-6b13e6e53ca6", _userScopeResponse.AccessToken);

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/UserModuleIntegrationTest.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/UserModuleIntegrationTest.cs
@@ -1,0 +1,338 @@
+﻿using Promact.OAuth.Client.Repository.User;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using Promact.OAuth.Client.Util.ExceptionHandler;
+using Promact.OAuth.Client.Util.StringConstant;
+using System.Net.Http;
+using Promact.OAuth.Client.Repository.BaseUrlSetUp;
+
+namespace Promact.OAuth.Client.Test
+{
+    public class UserModuleIntegrationTest : IntegrationBaseProvider
+    {
+        #region Private Variables
+        private readonly IUserModule _userModule;
+        private readonly IStringConstant _stringConstant;
+        #endregion
+
+        #region Constructor
+        public UserModuleIntegrationTest() : base()
+        {
+            _userModule = serviceProvider.GetService<IUserModule>();
+            _stringConstant = serviceProvider.GetService<IStringConstant>();
+            Repository.BaseUrlSetUp.PromactBaseUrl.PromactOAuthUrl = "http://localhost:35716/";
+        }
+        #endregion
+
+        #region Test Cases
+        /// <summary>
+        /// Integration Test GetPromactUserDetailBySlackUserIdAsync
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserDetailBySlackUserIdAsync()
+        {
+            var result = await _userModule.GetPromactUserDetailBySlackUserIdAsync("U7800454", _userScopeResponse.AccessToken);
+            Assert.Equal(result.Email, "roshni@promactinfo.com");
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserDetailBySlackUserIdAsync for exception UserNotFoundException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserDetailBySlackUserIdAsyncUserNotFoundException()
+        {
+            var result = await Assert.ThrowsAsync<UserNotFoundException>(() =>
+            _userModule.GetPromactUserDetailBySlackUserIdAsync("1df5sd5fs5d", _userScopeResponse.AccessToken));
+            Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserDetailBySlackUserIdAsync for exception HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserDetailBySlackUserIdAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            _userModule.GetPromactUserDetailBySlackUserIdAsync("1df5sd5fs5d", _userScopeResponse.AccessToken));
+            Assert.NotNull(result.Message);
+        }
+
+        /// <summary>
+        /// Integration Test GetListOfPromactTeamLeaderByUsersSlackIdAsync
+        /// </summary>
+        [Fact]
+        public async Task GetListOfPromactTeamLeaderByUsersSlackIdAsync()
+        {
+            var result = await _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync("U7800454", _userScopeResponse.AccessToken);
+            Assert.Equal(result.Count, 1);
+        }
+
+        /// <summary>
+        /// Integration Test GetListOfPromactTeamLeaderByUsersSlackIdAsync for UserNotFoundException
+        /// </summary>
+        [Fact]
+        public async Task GetListOfPromactTeamLeaderByUsersSlackIdAsyncUserNotFoundException()
+        {
+            var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
+            _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync("f5gd51fgd", _userScopeResponse.AccessToken));
+            Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
+        }
+
+        /// <summary>
+        /// Integration Test GetListOfPromactTeamLeaderByUsersSlackIdAsync for HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetListOfPromactTeamLeaderByUsersSlackIdAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync("f5gd51fgd", _userScopeResponse.AccessToken));
+            Assert.NotNull(result.Message);
+        }
+
+        /// <summary>
+        /// Integration Test GetListOfPromactManagementDetailsAsync
+        /// </summary>
+        [Fact]
+        public async Task GetListOfPromactManagementDetailsAsync()
+        {
+            var result = await _userModule.GetListOfPromactManagementDetailsAsync(_userScopeResponse.AccessToken);
+            Assert.Equal(result.Count, 2);
+        }
+
+        /// <summary>
+        /// Integration Test GetListOfPromactManagementDetailsAsync for HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetListOfPromactManagementDetailsAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(()=>
+            _userModule.GetListOfPromactManagementDetailsAsync(_userScopeResponse.AccessToken));
+            Assert.NotNull(result.Message);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserLeaveAllowedDetailsAsync
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserLeaveAllowedDetailsAsync()
+        {
+            var result = await _userModule.GetPromactUserLeaveAllowedDetailsAsync("U7800454",_userScopeResponse.AccessToken);
+            Assert.NotNull(result.CasualLeave);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserLeaveAllowedDetailsAsync for UserNotFoundException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserLeaveAllowedDetailsAsyncUserNotFoundException()
+        {
+            var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
+            _userModule.GetPromactUserLeaveAllowedDetailsAsync("sd4f1s2d1f2s", _userScopeResponse.AccessToken));
+            Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserLeaveAllowedDetailsAsync for HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserLeaveAllowedDetailsAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            _userModule.GetPromactUserLeaveAllowedDetailsAsync("sd4f1s2d1f2s", _userScopeResponse.AccessToken));
+            Assert.NotNull(result.Message);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserIsAdminOrNotAsync
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserIsAdminOrNotAsync()
+        {
+            var result = await _userModule.GetPromactUserIsAdminOrNotAsync("U7800454", _userScopeResponse.AccessToken);
+            Assert.Equal(result, true);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserIsAdminOrNotAsync for UserNotFoundException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserIsAdminOrNotAsyncUserNotFoundException()
+        {
+            var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
+            _userModule.GetPromactUserIsAdminOrNotAsync("d541f5sd1f5s", _userScopeResponse.AccessToken));
+            Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserIsAdminOrNotAsync for HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserIsAdminOrNotAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            _userModule.GetPromactUserIsAdminOrNotAsync("d541f5sd1f5s", _userScopeResponse.AccessToken));
+            Assert.NotNull(result.Message);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserDetailByIdAsync
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserDetailByIdAsync()
+        {
+            var result = await _userModule.GetPromactUserDetailByIdAsync("724f2dd4-49a4-4f6b-8edb-f957f1cbbc23", _userScopeResponse.AccessToken);
+            Assert.Equal(result.Email, "roshni@promactinfo.com");
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserDetailByIdAsync for UserNotFoundException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserDetailByIdAsyncUserNotFoundException()
+        {
+            var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
+            _userModule.GetPromactUserDetailByIdAsync("df1s5d1fs51df5s1d5f1s5d1s", _userScopeResponse.AccessToken));
+            Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserDetailByIdAsync for HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserDetailByIdAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            _userModule.GetPromactUserDetailByIdAsync("df1s5d1fs51df5s1d5f1s5d1s", _userScopeResponse.AccessToken));
+            Assert.NotNull(result.Message);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserRoleAsync
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserRoleAsync()
+        {
+            var result = await _userModule.GetPromactUserRoleAsync("724f2dd4-49a4-4f6b-8edb-f957f1cbbc23", _userScopeResponse.AccessToken);
+            Assert.NotNull(result);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserRoleAsync for UserNotFoundException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserRoleAsyncUserNotFoundException()
+        {
+            var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
+            _userModule.GetPromactUserRoleAsync("7dsa4f5sadfs4df5s4df5s4d5ssdf1", _userScopeResponse.AccessToken));
+            Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactUserRoleAsync for HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactUserRoleAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            _userModule.GetPromactUserRoleAsync("7dsa4f5sadfs4df5s4df5s4d5ssdf1", _userScopeResponse.AccessToken));
+            Assert.NotNull(result.Message);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactTeamMembersDetailsByUserIdAsync
+        /// </summary>
+        [Fact]
+        public async Task GetPromactTeamMembersDetailsByUserIdAsync()
+        {
+            var result = await _userModule.GetPromactTeamMembersDetailsByUserIdAsync("724f2dd4-49a4-4f6b-8edb-f957f1cbbc23", _userScopeResponse.AccessToken);
+            Assert.NotNull(result);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactTeamMembersDetailsByUserIdAsync for UserNotFoundException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactTeamMembersDetailsByUserIdAsyncUserNotFoundException()
+        {
+            var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
+            _userModule.GetPromactTeamMembersDetailsByUserIdAsync("df1s5d4fg5sfg51sdf5g1s5d1f5sddfs", _userScopeResponse.AccessToken));
+            Assert.NotNull(result);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactTeamMembersDetailsByUserIdAsync for HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactTeamMembersDetailsByUserIdAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            _userModule.GetPromactTeamMembersDetailsByUserIdAsync("df1s5d4fg5sfg51sdf5g1s5d1f5sddfs", _userScopeResponse.AccessToken));
+            Assert.NotNull(result);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactListOfUserDetailsBySlackGroupNameAsync
+        /// </summary>
+        [Fact]
+        public async Task GetPromactListOfUserDetailsBySlackGroupNameAsync()
+        {
+            var result = await _userModule.GetPromactListOfUserDetailsBySlackGroupNameAsync("Slash-Command", _userScopeResponse.AccessToken);
+            Assert.Equal(result.Count, 1);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactListOfUserDetailsBySlackGroupNameAsync for HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactListOfUserDetailsBySlackGroupNameAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(()=>
+            _userModule.GetPromactListOfUserDetailsBySlackGroupNameAsync("Slash-Command", _userScopeResponse.AccessToken));
+            Assert.NotNull(result.Message);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactListOfUsersDetailsByTeamLeaderIdAsync
+        /// </summary>
+        [Fact]
+        public async Task GetPromactListOfUsersDetailsByTeamLeaderIdAsync()
+        {
+            var result = await _userModule.GetPromactListOfUsersDetailsByTeamLeaderIdAsync("724f2dd4-49a4-4f6b-8edb-f957f1cbbc23", _userScopeResponse.AccessToken);
+            Assert.Equal(result.Count, 2);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactListOfUsersDetailsByTeamLeaderIdAsync for UserNotFoundException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactListOfUsersDetailsByTeamLeaderIdAsyncUserNotFoundException()
+        {
+            var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
+            _userModule.GetPromactListOfUsersDetailsByTeamLeaderIdAsync("fs5d1fg5sdf4g5s1df5s1d5f", _userScopeResponse.AccessToken));
+            Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
+        }
+
+        /// <summary>
+        /// Integration Test GetPromactListOfUsersDetailsByTeamLeaderIdAsync for HttpRequestException
+        /// </summary>
+        [Fact]
+        public async Task GetPromactListOfUsersDetailsByTeamLeaderIdAsyncHttpRequestException()
+        {
+            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            _userModule.GetPromactListOfUsersDetailsByTeamLeaderIdAsync("fs5d1fg5sdf4g5s1df5s1d5f", _userScopeResponse.AccessToken));
+            Assert.NotNull(result.Message);
+        }
+        #endregion
+    }
+}

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/UserModuleIntegrationTest.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/UserModuleIntegrationTest.cs
@@ -21,7 +21,7 @@ namespace Promact.OAuth.Client.Test
         {
             _userModule = serviceProvider.GetService<IUserModule>();
             _stringConstant = serviceProvider.GetService<IStringConstant>();
-            Repository.BaseUrlSetUp.PromactBaseUrl.PromactOAuthUrl = "http://localhost:35716/";
+            PromactBaseUrl.PromactOAuthUrl = "http://oauth.promactinfo.com/";
         }
         #endregion
 
@@ -32,8 +32,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserDetailBySlackUserIdAsync()
         {
-            var result = await _userModule.GetPromactUserDetailBySlackUserIdAsync("U7800454", _userScopeResponse.AccessToken);
-            Assert.Equal(result.Email, "roshni@promactinfo.com");
+            var result = await _userModule.GetPromactUserDetailBySlackUserIdAsync("8d29efae-d747-4fc6-a7f1-13f687bd5d67", _userScopeResponse.AccessToken);
+            Assert.Equal(result.Email, "admin@promactinfo.com");
         }
 
         /// <summary>
@@ -62,11 +62,11 @@ namespace Promact.OAuth.Client.Test
         /// <summary>
         /// Integration Test GetListOfPromactTeamLeaderByUsersSlackIdAsync
         /// </summary>
-        [Fact]
+        //[Fact]
         public async Task GetListOfPromactTeamLeaderByUsersSlackIdAsync()
         {
-            var result = await _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync("U7800454", _userScopeResponse.AccessToken);
-            Assert.Equal(result.Count, 1);
+            var result = await _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync("9cdc7982-25b9-45a4-afdc-6b13e6e53ca6", _userScopeResponse.AccessToken);
+            Assert.NotEqual(result.Count, 0);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Promact.OAuth.Client.Test
         public async Task GetListOfPromactManagementDetailsAsync()
         {
             var result = await _userModule.GetListOfPromactManagementDetailsAsync(_userScopeResponse.AccessToken);
-            Assert.Equal(result.Count, 2);
+            Assert.NotEqual(result.Count, 0);
         }
 
         /// <summary>
@@ -120,8 +120,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserLeaveAllowedDetailsAsync()
         {
-            var result = await _userModule.GetPromactUserLeaveAllowedDetailsAsync("U7800454",_userScopeResponse.AccessToken);
-            Assert.NotNull(result.CasualLeave);
+            var result = await _userModule.GetPromactUserLeaveAllowedDetailsAsync("d37a7afe-ae39-414d-b9fc-8150629a7f85", _userScopeResponse.AccessToken);
+            Assert.Equal(result.CasualLeave, 2);
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserIsAdminOrNotAsync()
         {
-            var result = await _userModule.GetPromactUserIsAdminOrNotAsync("U7800454", _userScopeResponse.AccessToken);
+            var result = await _userModule.GetPromactUserIsAdminOrNotAsync("8d29efae-d747-4fc6-a7f1-13f687bd5d67", _userScopeResponse.AccessToken);
             Assert.Equal(result, true);
         }
 
@@ -186,8 +186,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserDetailByIdAsync()
         {
-            var result = await _userModule.GetPromactUserDetailByIdAsync("724f2dd4-49a4-4f6b-8edb-f957f1cbbc23", _userScopeResponse.AccessToken);
-            Assert.Equal(result.Email, "roshni@promactinfo.com");
+            var result = await _userModule.GetPromactUserDetailByIdAsync("8d29efae-d747-4fc6-a7f1-13f687bd5d67", _userScopeResponse.AccessToken);
+            Assert.Equal(result.Email, "admin@promactinfo.com");
         }
 
         /// <summary>
@@ -219,8 +219,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserRoleAsync()
         {
-            var result = await _userModule.GetPromactUserRoleAsync("724f2dd4-49a4-4f6b-8edb-f957f1cbbc23", _userScopeResponse.AccessToken);
-            Assert.NotNull(result);
+            var result = await _userModule.GetPromactUserRoleAsync("8d29efae-d747-4fc6-a7f1-13f687bd5d67", _userScopeResponse.AccessToken);
+            Assert.NotEqual(result.Count, 0);
         }
 
         /// <summary>
@@ -252,8 +252,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactTeamMembersDetailsByUserIdAsync()
         {
-            var result = await _userModule.GetPromactTeamMembersDetailsByUserIdAsync("724f2dd4-49a4-4f6b-8edb-f957f1cbbc23", _userScopeResponse.AccessToken);
-            Assert.NotNull(result);
+            var result = await _userModule.GetPromactTeamMembersDetailsByUserIdAsync("8d29efae-d747-4fc6-a7f1-13f687bd5d67", _userScopeResponse.AccessToken);
+            Assert.NotEqual(result.Count, 0);
         }
 
         /// <summary>
@@ -285,8 +285,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactListOfUserDetailsBySlackGroupNameAsync()
         {
-            var result = await _userModule.GetPromactListOfUserDetailsBySlackGroupNameAsync("Slash-Command", _userScopeResponse.AccessToken);
-            Assert.Equal(result.Count, 1);
+            var result = await _userModule.GetPromactListOfUserDetailsBySlackGroupNameAsync("Slash-Command", _projectScopeResponse.AccessToken);
+            Assert.NotEqual(result.Count, 0);
         }
 
         /// <summary>
@@ -307,8 +307,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactListOfUsersDetailsByTeamLeaderIdAsync()
         {
-            var result = await _userModule.GetPromactListOfUsersDetailsByTeamLeaderIdAsync("724f2dd4-49a4-4f6b-8edb-f957f1cbbc23", _userScopeResponse.AccessToken);
-            Assert.Equal(result.Count, 2);
+            var result = await _userModule.GetPromactListOfUsersDetailsByTeamLeaderIdAsync("ea18f1db-6fa5-4050-8930-138e0b1ff21d", _userScopeResponse.AccessToken);
+            Assert.NotEqual(result.Count, 0);
         }
 
         /// <summary>

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/UserModuleIntegrationTest.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/UserModuleIntegrationTest.cs
@@ -13,15 +13,13 @@ namespace Promact.OAuth.Client.Test
     {
         #region Private Variables
         private readonly IUserModule _userModule;
-        private readonly IStringConstant _stringConstant;
         #endregion
 
         #region Constructor
         public UserModuleIntegrationTest() : base()
         {
             _userModule = serviceProvider.GetService<IUserModule>();
-            _stringConstant = serviceProvider.GetService<IStringConstant>();
-            PromactBaseUrl.PromactOAuthUrl = "http://oauth.promactinfo.com/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.PromactOAuthUrl;
         }
         #endregion
 
@@ -32,8 +30,9 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserDetailBySlackUserIdAsync()
         {
-            var result = await _userModule.GetPromactUserDetailBySlackUserIdAsync("8d29efae-d747-4fc6-a7f1-13f687bd5d67", _userScopeResponse.AccessToken);
-            Assert.Equal(result.Email, "admin@promactinfo.com");
+            var result = await _userModule.GetPromactUserDetailBySlackUserIdAsync(_stringConstant.AdminIdForIntegrationTest,
+                _userScopeResponse.AccessToken);
+            Assert.Equal(result.Email, _stringConstant.AdminEmailForTest);
         }
 
         /// <summary>
@@ -43,7 +42,8 @@ namespace Promact.OAuth.Client.Test
         public async Task GetPromactUserDetailBySlackUserIdAsyncUserNotFoundException()
         {
             var result = await Assert.ThrowsAsync<UserNotFoundException>(() =>
-            _userModule.GetPromactUserDetailBySlackUserIdAsync("1df5sd5fs5d", _userScopeResponse.AccessToken));
+            _userModule.GetPromactUserDetailBySlackUserIdAsync(_stringConstant.RandomUserIdForTest, 
+            _userScopeResponse.AccessToken));
             Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
         }
 
@@ -53,9 +53,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserDetailBySlackUserIdAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
-            _userModule.GetPromactUserDetailBySlackUserIdAsync("1df5sd5fs5d", _userScopeResponse.AccessToken));
+            _userModule.GetPromactUserDetailBySlackUserIdAsync(_stringConstant.RandomUserIdForTest, 
+            _userScopeResponse.AccessToken));
             Assert.NotNull(result.Message);
         }
 
@@ -65,7 +66,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetListOfPromactTeamLeaderByUsersSlackIdAsync()
         {
-            var result = await _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync("9cdc7982-25b9-45a4-afdc-6b13e6e53ca6", _userScopeResponse.AccessToken);
+            var result = await _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync(_stringConstant.UserIdForIntegrationTest, 
+                _userScopeResponse.AccessToken);
             Assert.NotEqual(result.Count, 0);
         }
 
@@ -76,7 +78,8 @@ namespace Promact.OAuth.Client.Test
         public async Task GetListOfPromactTeamLeaderByUsersSlackIdAsyncUserNotFoundException()
         {
             var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
-            _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync("f5gd51fgd", _userScopeResponse.AccessToken));
+            _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync(_stringConstant.RandomUserIdForTest, 
+            _userScopeResponse.AccessToken));
             Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
         }
 
@@ -86,9 +89,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetListOfPromactTeamLeaderByUsersSlackIdAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
-            _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync("f5gd51fgd", _userScopeResponse.AccessToken));
+            _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync(_stringConstant.RandomUserIdForTest, 
+            _userScopeResponse.AccessToken));
             Assert.NotNull(result.Message);
         }
 
@@ -108,7 +112,7 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetListOfPromactManagementDetailsAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(()=>
             _userModule.GetListOfPromactManagementDetailsAsync(_userScopeResponse.AccessToken));
             Assert.NotNull(result.Message);
@@ -120,7 +124,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserLeaveAllowedDetailsAsync()
         {
-            var result = await _userModule.GetPromactUserLeaveAllowedDetailsAsync("d37a7afe-ae39-414d-b9fc-8150629a7f85", _userScopeResponse.AccessToken);
+            var result = await _userModule.GetPromactUserLeaveAllowedDetailsAsync(_stringConstant.UserIdForIntegrationTest, 
+                _userScopeResponse.AccessToken);
             Assert.Equal(result.CasualLeave, 2);
         }
 
@@ -131,7 +136,8 @@ namespace Promact.OAuth.Client.Test
         public async Task GetPromactUserLeaveAllowedDetailsAsyncUserNotFoundException()
         {
             var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
-            _userModule.GetPromactUserLeaveAllowedDetailsAsync("sd4f1s2d1f2s", _userScopeResponse.AccessToken));
+            _userModule.GetPromactUserLeaveAllowedDetailsAsync(_stringConstant.RandomUserIdForTest, 
+            _userScopeResponse.AccessToken));
             Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
         }
 
@@ -141,9 +147,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserLeaveAllowedDetailsAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
-            _userModule.GetPromactUserLeaveAllowedDetailsAsync("sd4f1s2d1f2s", _userScopeResponse.AccessToken));
+            _userModule.GetPromactUserLeaveAllowedDetailsAsync(_stringConstant.RandomUserIdForTest, 
+            _userScopeResponse.AccessToken));
             Assert.NotNull(result.Message);
         }
 
@@ -153,7 +160,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserIsAdminOrNotAsync()
         {
-            var result = await _userModule.GetPromactUserIsAdminOrNotAsync("8d29efae-d747-4fc6-a7f1-13f687bd5d67", _userScopeResponse.AccessToken);
+            var result = await _userModule.GetPromactUserIsAdminOrNotAsync(_stringConstant.AdminIdForIntegrationTest, 
+                _userScopeResponse.AccessToken);
             Assert.Equal(result, true);
         }
 
@@ -164,7 +172,8 @@ namespace Promact.OAuth.Client.Test
         public async Task GetPromactUserIsAdminOrNotAsyncUserNotFoundException()
         {
             var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
-            _userModule.GetPromactUserIsAdminOrNotAsync("d541f5sd1f5s", _userScopeResponse.AccessToken));
+            _userModule.GetPromactUserIsAdminOrNotAsync(_stringConstant.RandomUserIdForTest, 
+            _userScopeResponse.AccessToken));
             Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
         }
 
@@ -174,9 +183,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserIsAdminOrNotAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
-            _userModule.GetPromactUserIsAdminOrNotAsync("d541f5sd1f5s", _userScopeResponse.AccessToken));
+            _userModule.GetPromactUserIsAdminOrNotAsync(_stringConstant.RandomUserIdForTest, 
+            _userScopeResponse.AccessToken));
             Assert.NotNull(result.Message);
         }
 
@@ -186,8 +196,9 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserDetailByIdAsync()
         {
-            var result = await _userModule.GetPromactUserDetailByIdAsync("8d29efae-d747-4fc6-a7f1-13f687bd5d67", _userScopeResponse.AccessToken);
-            Assert.Equal(result.Email, "admin@promactinfo.com");
+            var result = await _userModule.GetPromactUserDetailByIdAsync(_stringConstant.AdminIdForIntegrationTest, 
+                _userScopeResponse.AccessToken);
+            Assert.Equal(result.Email, _stringConstant.AdminEmailForTest);
         }
 
         /// <summary>
@@ -197,7 +208,8 @@ namespace Promact.OAuth.Client.Test
         public async Task GetPromactUserDetailByIdAsyncUserNotFoundException()
         {
             var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
-            _userModule.GetPromactUserDetailByIdAsync("df1s5d1fs51df5s1d5f1s5d1s", _userScopeResponse.AccessToken));
+            _userModule.GetPromactUserDetailByIdAsync(_stringConstant.RandomUserIdForTest, 
+            _userScopeResponse.AccessToken));
             Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
         }
 
@@ -207,9 +219,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserDetailByIdAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
-            _userModule.GetPromactUserDetailByIdAsync("df1s5d1fs51df5s1d5f1s5d1s", _userScopeResponse.AccessToken));
+            _userModule.GetPromactUserDetailByIdAsync(_stringConstant.RandomUserIdForTest, 
+            _userScopeResponse.AccessToken));
             Assert.NotNull(result.Message);
         }
 
@@ -219,7 +232,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserRoleAsync()
         {
-            var result = await _userModule.GetPromactUserRoleAsync("8d29efae-d747-4fc6-a7f1-13f687bd5d67", _userScopeResponse.AccessToken);
+            var result = await _userModule.GetPromactUserRoleAsync(_stringConstant.AdminIdForIntegrationTest, 
+                _userScopeResponse.AccessToken);
             Assert.NotEqual(result.Count, 0);
         }
 
@@ -230,7 +244,7 @@ namespace Promact.OAuth.Client.Test
         public async Task GetPromactUserRoleAsyncUserNotFoundException()
         {
             var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
-            _userModule.GetPromactUserRoleAsync("7dsa4f5sadfs4df5s4df5s4d5ssdf1", _userScopeResponse.AccessToken));
+            _userModule.GetPromactUserRoleAsync(_stringConstant.RandomUserIdForTest, _userScopeResponse.AccessToken));
             Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
         }
 
@@ -240,9 +254,9 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactUserRoleAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
-            _userModule.GetPromactUserRoleAsync("7dsa4f5sadfs4df5s4df5s4d5ssdf1", _userScopeResponse.AccessToken));
+            _userModule.GetPromactUserRoleAsync(_stringConstant.RandomUserIdForTest, _userScopeResponse.AccessToken));
             Assert.NotNull(result.Message);
         }
 
@@ -252,7 +266,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactTeamMembersDetailsByUserIdAsync()
         {
-            var result = await _userModule.GetPromactTeamMembersDetailsByUserIdAsync("8d29efae-d747-4fc6-a7f1-13f687bd5d67", _userScopeResponse.AccessToken);
+            var result = await _userModule.GetPromactTeamMembersDetailsByUserIdAsync(_stringConstant.AdminIdForIntegrationTest, 
+                _userScopeResponse.AccessToken);
             Assert.NotEqual(result.Count, 0);
         }
 
@@ -263,7 +278,8 @@ namespace Promact.OAuth.Client.Test
         public async Task GetPromactTeamMembersDetailsByUserIdAsyncUserNotFoundException()
         {
             var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
-            _userModule.GetPromactTeamMembersDetailsByUserIdAsync("df1s5d4fg5sfg51sdf5g1s5d1f5sddfs", _userScopeResponse.AccessToken));
+            _userModule.GetPromactTeamMembersDetailsByUserIdAsync(_stringConstant.RandomUserIdForTest, 
+            _userScopeResponse.AccessToken));
             Assert.NotNull(result);
         }
 
@@ -273,9 +289,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactTeamMembersDetailsByUserIdAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
-            _userModule.GetPromactTeamMembersDetailsByUserIdAsync("df1s5d4fg5sfg51sdf5g1s5d1f5sddfs", _userScopeResponse.AccessToken));
+            _userModule.GetPromactTeamMembersDetailsByUserIdAsync(_stringConstant.RandomUserIdForTest, 
+            _userScopeResponse.AccessToken));
             Assert.NotNull(result);
         }
 
@@ -285,7 +302,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactListOfUserDetailsBySlackGroupNameAsync()
         {
-            var result = await _userModule.GetPromactListOfUserDetailsBySlackGroupNameAsync("Slash-Command", _projectScopeResponse.AccessToken);
+            var result = await _userModule.GetPromactListOfUserDetailsBySlackGroupNameAsync(_stringConstant.ProjectGroupNameForTest, 
+                _projectScopeResponse.AccessToken);
             Assert.NotEqual(result.Count, 0);
         }
 
@@ -295,9 +313,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactListOfUserDetailsBySlackGroupNameAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(()=>
-            _userModule.GetPromactListOfUserDetailsBySlackGroupNameAsync("Slash-Command", _userScopeResponse.AccessToken));
+            _userModule.GetPromactListOfUserDetailsBySlackGroupNameAsync(_stringConstant.ProjectGroupNameForTest, 
+            _userScopeResponse.AccessToken));
             Assert.NotNull(result.Message);
         }
 
@@ -307,7 +326,8 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactListOfUsersDetailsByTeamLeaderIdAsync()
         {
-            var result = await _userModule.GetPromactListOfUsersDetailsByTeamLeaderIdAsync("ea18f1db-6fa5-4050-8930-138e0b1ff21d", _userScopeResponse.AccessToken);
+            var result = await _userModule.GetPromactListOfUsersDetailsByTeamLeaderIdAsync(_stringConstant.TeamLeaderIdForIntegrationTest,
+                _userScopeResponse.AccessToken);
             Assert.NotEqual(result.Count, 0);
         }
 
@@ -318,7 +338,8 @@ namespace Promact.OAuth.Client.Test
         public async Task GetPromactListOfUsersDetailsByTeamLeaderIdAsyncUserNotFoundException()
         {
             var result = await Assert.ThrowsAsync<UserNotFoundException>(()=>
-            _userModule.GetPromactListOfUsersDetailsByTeamLeaderIdAsync("fs5d1fg5sdf4g5s1df5s1d5f", _userScopeResponse.AccessToken));
+            _userModule.GetPromactListOfUsersDetailsByTeamLeaderIdAsync(_stringConstant.RandomUserIdForTest,
+            _userScopeResponse.AccessToken));
             Assert.Equal(result.Message, _stringConstant.UserNotFoundExceptionMessage);
         }
 
@@ -328,9 +349,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task GetPromactListOfUsersDetailsByTeamLeaderIdAsyncHttpRequestException()
         {
-            PromactBaseUrl.PromactOAuthUrl = "http://localhost:1234/";
+            PromactBaseUrl.PromactOAuthUrl = _stringConstant.RandomUrlForTest;
             var result = await Assert.ThrowsAsync<HttpRequestException>(() =>
-            _userModule.GetPromactListOfUsersDetailsByTeamLeaderIdAsync("fs5d1fg5sdf4g5s1df5s1d5f", _userScopeResponse.AccessToken));
+            _userModule.GetPromactListOfUsersDetailsByTeamLeaderIdAsync(_stringConstant.RandomUserIdForTest,
+            _userScopeResponse.AccessToken));
             Assert.NotNull(result.Message);
         }
         #endregion

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/UserModuleTest.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/UserModuleTest.cs
@@ -47,9 +47,9 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetPromactUserDetailBySlackUserIdAsync()
         {
-            var contentUrl = string.Format(_stringConstant.GetPromactUserDetialBySlackUserIdUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetPromactUserDetialBySlackUserIdUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, SerializationOfUser(), HttpStatusCode.OK);
-            var expectedResult = await _userModule.GetPromactUserDetailBySlackUserIdAsync(_stringConstant.SlackUserIdForTest,
+            var expectedResult = await _userModule.GetPromactUserDetailBySlackUserIdAsync(_stringConstant.UserIdForTest,
                 _stringConstant.AccessTokenForTest);
             Assert.Equal(_stringConstant.UserIdForTest, expectedResult.Id);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
@@ -61,10 +61,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetPromactUserDetailBySlackUserIdAsyncForAuthenticationException()
         {
-            var contentUrl = string.Format(_stringConstant.GetPromactUserDetialBySlackUserIdUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetPromactUserDetialBySlackUserIdUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, null, HttpStatusCode.Forbidden);
             var expectedResult = await Assert.ThrowsAnyAsync<AuthenticationException>(() =>
-            _userModule.GetPromactUserDetailBySlackUserIdAsync(_stringConstant.SlackUserIdForTest, _stringConstant.AccessTokenForTest));
+            _userModule.GetPromactUserDetailBySlackUserIdAsync(_stringConstant.UserIdForTest, _stringConstant.AccessTokenForTest));
             Assert.Equal(_stringConstant.AccessTokenNotMatchedException, expectedResult.Message);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
         }
@@ -75,10 +75,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetPromactUserDetailBySlackUserIdAsyncForHttpRequestException()
         {
-            var contentUrl = string.Format(_stringConstant.GetPromactUserDetialBySlackUserIdUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetPromactUserDetialBySlackUserIdUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, null, HttpStatusCode.GatewayTimeout);
             var expectedResult = await Assert.ThrowsAnyAsync<HttpRequestException>(() =>
-            _userModule.GetPromactUserDetailBySlackUserIdAsync(_stringConstant.SlackUserIdForTest, _stringConstant.AccessTokenForTest));
+            _userModule.GetPromactUserDetailBySlackUserIdAsync(_stringConstant.UserIdForTest, _stringConstant.AccessTokenForTest));
             Assert.Equal(_stringConstant.HttpRequestExceptionErrorMessageForTest, expectedResult.Message);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
         }
@@ -89,10 +89,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetPromactUserDetailBySlackUserIdAsyncForUserNotFoundException()
         {
-            var contentUrl = string.Format(_stringConstant.GetPromactUserDetialBySlackUserIdUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetPromactUserDetialBySlackUserIdUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, null, HttpStatusCode.BadRequest);
             var expectedResult = await Assert.ThrowsAnyAsync<UserNotFoundException>(() =>
-            _userModule.GetPromactUserDetailBySlackUserIdAsync(_stringConstant.SlackUserIdForTest, _stringConstant.AccessTokenForTest));
+            _userModule.GetPromactUserDetailBySlackUserIdAsync(_stringConstant.UserIdForTest, _stringConstant.AccessTokenForTest));
             Assert.Equal(_stringConstant.UserNotFoundExceptionMessage, expectedResult.Message);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
         }
@@ -104,9 +104,9 @@ namespace Promact.OAuth.Client.Test
         public async Task TestGetListOfPromactTeamLeaderByUsersSlackIdAsync()
         {
             var contentUrl = string.Format(_stringConstant.GetListOfPromactTeamLeaderByUsersSlackIdUrl, 
-                _stringConstant.SlackUserIdForTest);
+                _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, SerializationOfListOfUser(), HttpStatusCode.OK);
-            var expectedResult = await _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync(_stringConstant.SlackUserIdForTest,
+            var expectedResult = await _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync(_stringConstant.UserIdForTest,
                 _stringConstant.AccessTokenForTest);
             Assert.Equal(true, expectedResult.Any());
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
@@ -118,10 +118,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetListOfPromactTeamLeaderByUsersSlackIdAsyncForAuthenticationException()
         {
-            var contentUrl = string.Format(_stringConstant.GetListOfPromactTeamLeaderByUsersSlackIdUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetListOfPromactTeamLeaderByUsersSlackIdUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, null, HttpStatusCode.Forbidden);
             var expectedResult = await Assert.ThrowsAnyAsync<AuthenticationException>(() =>
-            _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync(_stringConstant.SlackUserIdForTest, _stringConstant.AccessTokenForTest));
+            _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync(_stringConstant.UserIdForTest, _stringConstant.AccessTokenForTest));
             Assert.Equal(_stringConstant.AccessTokenNotMatchedException, expectedResult.Message);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
         }
@@ -132,10 +132,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetListOfPromactTeamLeaderByUsersSlackIdAsyncForHttpRequestException()
         {
-            var contentUrl = string.Format(_stringConstant.GetListOfPromactTeamLeaderByUsersSlackIdUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetListOfPromactTeamLeaderByUsersSlackIdUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, null, HttpStatusCode.GatewayTimeout);
             var expectedResult = await Assert.ThrowsAnyAsync<HttpRequestException>(() =>
-            _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync(_stringConstant.SlackUserIdForTest, _stringConstant.AccessTokenForTest));
+            _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync(_stringConstant.UserIdForTest, _stringConstant.AccessTokenForTest));
             Assert.Equal(_stringConstant.HttpRequestExceptionErrorMessageForTest, expectedResult.Message);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
         }
@@ -146,10 +146,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetListOfPromactTeamLeaderByUsersSlackIdAsyncForUserNotFoundException()
         {
-            var contentUrl = string.Format(_stringConstant.GetListOfPromactTeamLeaderByUsersSlackIdUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetListOfPromactTeamLeaderByUsersSlackIdUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, null, HttpStatusCode.BadRequest);
             var expectedResult = await Assert.ThrowsAnyAsync<UserNotFoundException>(() =>
-            _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync(_stringConstant.SlackUserIdForTest, _stringConstant.AccessTokenForTest));
+            _userModule.GetListOfPromactTeamLeaderByUsersSlackIdAsync(_stringConstant.UserIdForTest, _stringConstant.AccessTokenForTest));
             Assert.Equal(_stringConstant.UserNotFoundExceptionMessage, expectedResult.Message);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
         }
@@ -216,9 +216,9 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetPromactUserLeaveAllowedDetailsAsync()
         {
-            var contentUrl = string.Format(_stringConstant.GetPromactUserLeaveAllowedDetailsUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetPromactUserLeaveAllowedDetailsUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, SerializationOfLeaveAllowed(), HttpStatusCode.OK);
-            var expectedResult = await _userModule.GetPromactUserLeaveAllowedDetailsAsync(_stringConstant.SlackUserIdForTest,
+            var expectedResult = await _userModule.GetPromactUserLeaveAllowedDetailsAsync(_stringConstant.UserIdForTest,
                 _stringConstant.AccessTokenForTest);
             Assert.Equal(Convert.ToInt32(_stringConstant.CasualLeaveForTest), expectedResult.CasualLeave);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
@@ -230,10 +230,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetPromactUserLeaveAllowedDetailsAsyncForAuthenticationException()
         {
-            var contentUrl = string.Format(_stringConstant.GetPromactUserLeaveAllowedDetailsUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetPromactUserLeaveAllowedDetailsUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, null, HttpStatusCode.Forbidden);
             var expectedResult = await Assert.ThrowsAnyAsync<AuthenticationException>(() =>
-            _userModule.GetPromactUserLeaveAllowedDetailsAsync(_stringConstant.SlackUserIdForTest, _stringConstant.AccessTokenForTest));
+            _userModule.GetPromactUserLeaveAllowedDetailsAsync(_stringConstant.UserIdForTest, _stringConstant.AccessTokenForTest));
             Assert.Equal(_stringConstant.AccessTokenNotMatchedException, expectedResult.Message);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
         }
@@ -244,10 +244,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetPromactUserLeaveAllowedDetailsAsyncForHttpRequestException()
         {
-            var contentUrl = string.Format(_stringConstant.GetPromactUserLeaveAllowedDetailsUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetPromactUserLeaveAllowedDetailsUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, null, HttpStatusCode.GatewayTimeout);
             var expectedResult = await Assert.ThrowsAnyAsync<HttpRequestException>(() =>
-            _userModule.GetPromactUserLeaveAllowedDetailsAsync(_stringConstant.SlackUserIdForTest, _stringConstant.AccessTokenForTest));
+            _userModule.GetPromactUserLeaveAllowedDetailsAsync(_stringConstant.UserIdForTest, _stringConstant.AccessTokenForTest));
             Assert.Equal(_stringConstant.HttpRequestExceptionErrorMessageForTest, expectedResult.Message);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
         }
@@ -258,10 +258,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetPromactUserLeaveAllowedDetailsAsyncForUserNotFoundException()
         {
-            var contentUrl = string.Format(_stringConstant.GetPromactUserLeaveAllowedDetailsUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetPromactUserLeaveAllowedDetailsUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, null, HttpStatusCode.BadRequest);
             var expectedResult = await Assert.ThrowsAnyAsync<UserNotFoundException>(() =>
-            _userModule.GetPromactUserLeaveAllowedDetailsAsync(_stringConstant.SlackUserIdForTest, _stringConstant.AccessTokenForTest));
+            _userModule.GetPromactUserLeaveAllowedDetailsAsync(_stringConstant.UserIdForTest, _stringConstant.AccessTokenForTest));
             Assert.Equal(_stringConstant.UserNotFoundExceptionMessage, expectedResult.Message);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
         }
@@ -272,9 +272,9 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetPromactUserIsAdminOrNotAsync()
         {
-            var contentUrl = string.Format(_stringConstant.GetPromactUserIsAdminOrNotUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetPromactUserIsAdminOrNotUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, true.ToString().ToLower(), HttpStatusCode.OK);
-            var expectedResult = await _userModule.GetPromactUserIsAdminOrNotAsync(_stringConstant.SlackUserIdForTest,
+            var expectedResult = await _userModule.GetPromactUserIsAdminOrNotAsync(_stringConstant.UserIdForTest,
                 _stringConstant.AccessTokenForTest);
             Assert.Equal(true, expectedResult);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
@@ -286,10 +286,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetPromactUserIsAdminOrNotAsyncForAuthenticationException()
         {
-            var contentUrl = string.Format(_stringConstant.GetPromactUserIsAdminOrNotUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetPromactUserIsAdminOrNotUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, null, HttpStatusCode.Forbidden);
             var expectedResult = await Assert.ThrowsAnyAsync<AuthenticationException>(() =>
-            _userModule.GetPromactUserIsAdminOrNotAsync(_stringConstant.SlackUserIdForTest, _stringConstant.AccessTokenForTest));
+            _userModule.GetPromactUserIsAdminOrNotAsync(_stringConstant.UserIdForTest, _stringConstant.AccessTokenForTest));
             Assert.Equal(_stringConstant.AccessTokenNotMatchedException, expectedResult.Message);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
         }
@@ -300,10 +300,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetPromactUserIsAdminOrNotAsyncForHttpRequestException()
         {
-            var contentUrl = string.Format(_stringConstant.GetPromactUserIsAdminOrNotUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetPromactUserIsAdminOrNotUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, null, HttpStatusCode.GatewayTimeout);
             var expectedResult = await Assert.ThrowsAnyAsync<HttpRequestException>(() =>
-            _userModule.GetPromactUserIsAdminOrNotAsync(_stringConstant.SlackUserIdForTest, _stringConstant.AccessTokenForTest));
+            _userModule.GetPromactUserIsAdminOrNotAsync(_stringConstant.UserIdForTest, _stringConstant.AccessTokenForTest));
             Assert.Equal(_stringConstant.HttpRequestExceptionErrorMessageForTest, expectedResult.Message);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
         }
@@ -314,10 +314,10 @@ namespace Promact.OAuth.Client.Test
         [Fact]
         public async Task TestGetPromactUserIsAdminOrNotAsyncForUserNotFoundException()
         {
-            var contentUrl = string.Format(_stringConstant.GetPromactUserIsAdminOrNotUrl, _stringConstant.SlackUserIdForTest);
+            var contentUrl = string.Format(_stringConstant.GetPromactUserIsAdminOrNotUrl, _stringConstant.UserIdForTest);
             MockingHttpClientService(contentUrl, null, HttpStatusCode.BadRequest);
             var expectedResult = await Assert.ThrowsAnyAsync<UserNotFoundException>(() =>
-            _userModule.GetPromactUserIsAdminOrNotAsync(_stringConstant.SlackUserIdForTest, _stringConstant.AccessTokenForTest));
+            _userModule.GetPromactUserIsAdminOrNotAsync(_stringConstant.UserIdForTest, _stringConstant.AccessTokenForTest));
             Assert.Equal(_stringConstant.UserNotFoundExceptionMessage, expectedResult.Message);
             _mockHttpClientService.Verify(x => x.GetAsync(_stringConstant.AccessTokenForTest, contentUrl), Times.Once);
         }
@@ -617,7 +617,6 @@ namespace Promact.OAuth.Client.Test
             user.IsActive = true;
             user.NumberOfCasualLeave = 9;
             user.NumberOfSickLeave = 6;
-            user.SlackUserId = _stringConstant.SlackUserIdForTest;
             user.UserName = _stringConstant.EmailRandomValueForTest;
             userList.Add(user);
             userRole.UserName = _stringConstant.EmailRandomValueForTest;

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/project.json
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/project.json
@@ -7,8 +7,6 @@
     "Promact.OAuth.Client": "1.0.0-*",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "Microsoft.AspNet.TestHost": "1.0.0-rc1-final",
-    "Microsoft.AspNetCore.Hosting.Abstractions": "1.2.0-preview1-22929",
     "IdentityServer4": "1.1.0"
   },
 

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/project.json
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client.Test/project.json
@@ -6,7 +6,10 @@
     "Moq": "4.6.38-alpha",
     "Promact.OAuth.Client": "1.0.0-*",
     "xunit": "2.2.0-beta2-build3300",
-    "dotnet-test-xunit": "2.2.0-preview2-build1029"
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
+    "Microsoft.AspNet.TestHost": "1.0.0-rc1-final",
+    "Microsoft.AspNetCore.Hosting.Abstractions": "1.2.0-preview1-22929",
+    "IdentityServer4": "1.1.0"
   },
 
   "frameworks": {

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/DomainModel/PromactAuthenticationOptions.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/DomainModel/PromactAuthenticationOptions.cs
@@ -1,5 +1,7 @@
 ﻿#if NET461
 using Microsoft.Owin.Security.OpenIdConnect;
+#else
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 #endif
 using System.Collections.Generic;
 
@@ -47,6 +49,11 @@ namespace Promact.OAuth.Client.DomainModel
         /// to notify when processing OpenIdConnect messages.
         /// </summary>
         public OpenIdConnectAuthenticationNotifications Notifications { get; set; }
+#else
+        /// <summary>
+        /// Event Property of OpenIdConnection
+        /// </summary>
+        public OpenIdConnectEvents Event { get; set; }
 #endif
     }
 }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/DomainModel/User.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/DomainModel/User.cs
@@ -54,10 +54,5 @@
         /// User's unique name
         /// </summary>
         public string UniqueName { get { return FirstName + "-" + Email; } }
-
-        /// <summary>
-        /// User's slack user Id
-        /// </summary>
-        public string SlackUserId { get; set; }
     }
 }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Middleware/AuthenticationMiddleware.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Middleware/AuthenticationMiddleware.cs
@@ -60,6 +60,7 @@ namespace Promact.OAuth.Client.Middleware
             {
                 openIdConnecOptions.Scope.Add(scope.ToString());
             }
+            openIdConnecOptions.Events = options.Event;
             openIdConnecOptions.AuthenticationScheme = _stringConstant.OIDCAuthenticationScheme;
             openIdConnecOptions.SignInScheme = _stringConstant.SignInSchemeCookies;
             openIdConnecOptions.Authority = options.Authority;

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Middleware/AuthenticationMiddleware.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Middleware/AuthenticationMiddleware.cs
@@ -1,5 +1,6 @@
 ﻿using Promact.OAuth.Client.Util.StringConstant;
 using Promact.OAuth.Client.DomainModel;
+using Promact.OAuth.Client.Repository.BaseUrlSetUp;
 #if NET461
 using Owin;
 using Microsoft.Owin.Security.OpenIdConnect;
@@ -39,6 +40,7 @@ namespace Promact.OAuth.Client.Middleware
             openIdConnectAuthenticationOptions.PostLogoutRedirectUri = options.LogoutUrl;
             openIdConnectAuthenticationOptions.UseTokenLifetime = true;
             openIdConnectAuthenticationOptions.Notifications = options.Notifications;
+            PromactBaseUrl.PromactOAuthUrl = options.Authority;
             return app.UseOpenIdConnectAuthentication(openIdConnectAuthenticationOptions);
         }
 #else
@@ -71,7 +73,7 @@ namespace Promact.OAuth.Client.Middleware
             openIdConnecOptions.AutomaticChallenge = true;
             openIdConnecOptions.PostLogoutRedirectUri = options.LogoutUrl;
             openIdConnecOptions.UseTokenLifetime = true;
-            openIdConnecOptions.AuthenticationMethod = OpenIdConnectRedirectBehavior.RedirectGet;
+            PromactBaseUrl.PromactOAuthUrl = options.Authority;
             return app.UseOpenIdConnectAuthentication(openIdConnecOptions);
         }
 #endif

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Repository/BaseUrlSetUp/PromactBaseUrl.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Repository/BaseUrlSetUp/PromactBaseUrl.cs
@@ -1,0 +1,28 @@
+﻿namespace Promact.OAuth.Client.Repository.BaseUrlSetUp
+{
+    /// <summary>
+    /// Promact OAuth base url static class
+    /// </summary>
+    public static class PromactBaseUrl
+    {
+        /// <summary>
+        /// Promact OAuth's static base url
+        /// </summary>
+        private static string _promactBaseUrl;
+
+        /// <summary>
+        /// Promact OAuth's static base url
+        /// </summary>
+        public static string PromactOAuthUrl
+        {
+            get
+            {
+                return _promactBaseUrl;
+            }
+            set
+            {
+                _promactBaseUrl = value;
+            }
+        }
+    }
+}

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Repository/User/IUserModule.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Repository/User/IUserModule.cs
@@ -14,23 +14,23 @@ namespace Promact.OAuth.Client.Repository.User
         /// <summary>
         /// Get promact user details by user slack Id
         /// </summary>
-        /// <param name="userSlackId">user's slack Id</param>
+        /// <param name="userId">user's Id</param>
         /// <param name="userPromactAccessToken">user's promact access token</param>
         /// <returns>User details</returns>
         /// <exception cref="AuthenticationException">When user's access token is not allowed</exception>
         /// <exception cref="HttpRequestException">When promact oauth server is closed</exception>
         /// <exception cref="UserNotFoundException">When user details not found</exception>
-        Task<DomainModel.User> GetPromactUserDetailBySlackUserIdAsync(string userSlackId, string userPromactAccessToken);
+        Task<DomainModel.User> GetPromactUserDetailBySlackUserIdAsync(string userId, string userPromactAccessToken);
         /// <summary>
         /// Get promact's team leader list by user slack Id 
         /// </summary>
-        /// <param name="userSlackId">user's slack Id</param>
+        /// <param name="userId">user's Id</param>
         /// <param name="userPromactAccessToken">user's promact access token</param>
         /// <returns>list of team leader details</returns>
         /// <exception cref="AuthenticationException">When user's access token is not allowed</exception>
         /// <exception cref="HttpRequestException">When promact oauth server is closed</exception>
         /// <exception cref="UserNotFoundException">When user details not found</exception>
-        Task<List<DomainModel.User>> GetListOfPromactTeamLeaderByUsersSlackIdAsync(string userSlackId, string userPromactAccessToken);
+        Task<List<DomainModel.User>> GetListOfPromactTeamLeaderByUsersSlackIdAsync(string userId, string userPromactAccessToken);
         /// <summary>
         /// Get promact's all management list
         /// </summary>
@@ -43,23 +43,23 @@ namespace Promact.OAuth.Client.Repository.User
         /// <summary>
         /// Get promact's user leave allowed detail by slack user Id
         /// </summary>
-        /// <param name="userSlackId">user's slack Id</param>
+        /// <param name="userId">user's Id</param>
         /// <param name="userPromactAccessToken">user's promact access token</param>
         /// <returns>leave allowed details</returns>
         /// <exception cref="AuthenticationException">When user's access token is not allowed</exception>
         /// <exception cref="HttpRequestException">When promact oauth server is closed</exception>
         /// <exception cref="UserNotFoundException">When user details not found</exception>
-        Task<DomainModel.LeaveAllowed> GetPromactUserLeaveAllowedDetailsAsync(string userSlackId, string userPromactAccessToken);
+        Task<DomainModel.LeaveAllowed> GetPromactUserLeaveAllowedDetailsAsync(string userId, string userPromactAccessToken);
         /// <summary>
         /// Get promact's user is admin or not by slack user Id
         /// </summary>
-        /// <param name="userSlackId">user's slack Id</param>
+        /// <param name="userId">user's Id</param>
         /// <param name="userPromactAccessToken">user's promact access token</param>
         /// <returns>true or false</returns>
         /// <exception cref="AuthenticationException">When user's access token is not allowed</exception>
         /// <exception cref="HttpRequestException">When promact oauth server is closed</exception>
         /// <exception cref="UserNotFoundException">When user details not found</exception>
-        Task<bool> GetPromactUserIsAdminOrNotAsync(string userSlackId, string userPromactAccessToken);
+        Task<bool> GetPromactUserIsAdminOrNotAsync(string userId, string userPromactAccessToken);
         /// <summary>
         /// Get promact's user details by user Id
         /// </summary>

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Repository/User/UserModule.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Repository/User/UserModule.cs
@@ -37,15 +37,15 @@ namespace Promact.OAuth.Client.Repository.User
         /// <summary>
         /// Get promact user details by user slack Id
         /// </summary>
-        /// <param name="userSlackId">user's slack Id</param>
+        /// <param name="userId">user's Id</param>
         /// <param name="userPromactAccessToken">user's promact access token</param>
         /// <returns>User details</returns>
         /// <exception cref="AuthenticationException">When user's access token is not allowed</exception>
         /// <exception cref="HttpRequestException">When promact oauth server is closed</exception>
         /// <exception cref="UserNotFoundException">When user details not found</exception>
-        public async Task<DomainModel.User> GetPromactUserDetailBySlackUserIdAsync(string userSlackId, string userPromactAccessToken)
+        public async Task<DomainModel.User> GetPromactUserDetailBySlackUserIdAsync(string userId, string userPromactAccessToken)
         {
-            var url = string.Format(_stringConstant.GetPromactUserDetialBySlackUserIdUrl, userSlackId);
+            var url = string.Format(_stringConstant.GetPromactUserDetialBySlackUserIdUrl, userId);
             var result = await _httpClient.GetAsync(userPromactAccessToken, url);
             if (result.Status == System.Net.HttpStatusCode.OK)
             {
@@ -63,15 +63,15 @@ namespace Promact.OAuth.Client.Repository.User
         /// <summary>
         /// Get promact's team leader list by user slack Id 
         /// </summary>
-        /// <param name="userSlackId">user's slack Id</param>
+        /// <param name="userId">user's Id</param>
         /// <param name="userPromactAccessToken">user's promact access token</param>
         /// <returns>list of team leader details</returns>
         /// <exception cref="AuthenticationException">When user's access token is not allowed</exception>
         /// <exception cref="HttpRequestException">When promact oauth server is closed</exception>
         /// <exception cref="UserNotFoundException">When user details not found</exception>
-        public async Task<List<DomainModel.User>> GetListOfPromactTeamLeaderByUsersSlackIdAsync(string userSlackId, string userPromactAccessToken)
+        public async Task<List<DomainModel.User>> GetListOfPromactTeamLeaderByUsersSlackIdAsync(string userId, string userPromactAccessToken)
         {
-            var url = string.Format(_stringConstant.GetListOfPromactTeamLeaderByUsersSlackIdUrl, userSlackId);
+            var url = string.Format(_stringConstant.GetListOfPromactTeamLeaderByUsersSlackIdUrl, userId);
             var result = await _httpClient.GetAsync(userPromactAccessToken, url);
             if (result.Status == System.Net.HttpStatusCode.OK)
             {
@@ -114,15 +114,15 @@ namespace Promact.OAuth.Client.Repository.User
         /// <summary>
         /// Get promact's user leave allowed detail by slack user Id
         /// </summary>
-        /// <param name="userSlackId">user's slack Id</param>
+        /// <param name="userId">user's Id</param>
         /// <param name="userPromactAccessToken">user's promact access token</param>
         /// <returns>leave allowed details</returns>
         /// <exception cref="AuthenticationException">When user's access token is not allowed</exception>
         /// <exception cref="HttpRequestException">When promact oauth server is closed</exception>
         /// <exception cref="UserNotFoundException">When user details not found</exception>
-        public async Task<LeaveAllowed> GetPromactUserLeaveAllowedDetailsAsync(string userSlackId, string userPromactAccessToken)
+        public async Task<LeaveAllowed> GetPromactUserLeaveAllowedDetailsAsync(string userId, string userPromactAccessToken)
         {
-            var url = string.Format(_stringConstant.GetPromactUserLeaveAllowedDetailsUrl, userSlackId);
+            var url = string.Format(_stringConstant.GetPromactUserLeaveAllowedDetailsUrl, userId);
             var result = await _httpClient.GetAsync(userPromactAccessToken, url);
             if (result.Status == System.Net.HttpStatusCode.OK)
             {
@@ -140,15 +140,15 @@ namespace Promact.OAuth.Client.Repository.User
         /// <summary>
         /// Get promact's user is admin or not by slack user Id
         /// </summary>
-        /// <param name="userSlackId">user's slack Id</param>
+        /// <param name="userId">user's Id</param>
         /// <param name="userPromactAccessToken">user's promact access token</param>
         /// <returns>true or false</returns>
         /// <exception cref="AuthenticationException">When user's access token is not allowed</exception>
         /// <exception cref="HttpRequestException">When promact oauth server is closed</exception>
         /// <exception cref="UserNotFoundException">When user details not found</exception>
-        public async Task<bool> GetPromactUserIsAdminOrNotAsync(string userSlackId, string userPromactAccessToken)
+        public async Task<bool> GetPromactUserIsAdminOrNotAsync(string userId, string userPromactAccessToken)
         {
-            var url = string.Format(_stringConstant.GetPromactUserIsAdminOrNotUrl, userSlackId);
+            var url = string.Format(_stringConstant.GetPromactUserIsAdminOrNotUrl, userId);
             var result = await _httpClient.GetAsync(userPromactAccessToken, url);
             if (result.Status == System.Net.HttpStatusCode.OK)
             {

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/HttpClientWrapper/HttpClientService.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/HttpClientWrapper/HttpClientService.cs
@@ -1,4 +1,5 @@
 ﻿using Promact.OAuth.Client.DomainModel;
+using Promact.OAuth.Client.Repository.BaseUrlSetUp;
 using Promact.OAuth.Client.Util.StringConstant;
 using System;
 using System.Net.Http;
@@ -41,7 +42,7 @@ namespace Promact.OAuth.Client.Util.HttpClientWrapper
             try
             {
                 _httpClient = new HttpClient();
-                _httpClient.BaseAddress = new Uri(_stringConstant.PromactOAuthBaseUrl);
+                _httpClient.BaseAddress = new Uri(PromactBaseUrl.PromactOAuthUrl);
                 // Added access token to request header if provided by user
                 if (!String.IsNullOrEmpty(accessToken))
                 {

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/IStringConstant.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/IStringConstant.cs
@@ -130,5 +130,48 @@
         /// </summary>
         string ResponseTypeCodeAndIdToken { get; }
         #endregion
+
+        #region Integration Test Cases
+        /// <summary>
+        /// String Id of Admin for Test
+        /// </summary>
+        string AdminIdForIntegrationTest { get; }
+        /// <summary>
+        /// String Id of User for Test
+        /// </summary>
+        string UserIdForIntegrationTest { get; }
+        /// <summary>
+        /// Random Id for Test cases
+        /// </summary>
+        string RandomUserIdForTest { get; }
+        /// <summary>
+        /// String Id of TeamLeader for Test
+        /// </summary>
+        string TeamLeaderIdForIntegrationTest { get; }
+        /// <summary>
+        /// String Email address of Admin
+        /// </summary>
+        string AdminEmailForTest { get; }
+        /// <summary>
+        /// String Project group name for test
+        /// </summary>
+        string ProjectGroupNameForTest { get; }
+        /// <summary>
+        /// Random Url for test
+        /// </summary>
+        string RandomUrlForTest { get; }
+        /// <summary>
+        /// Promact Oauth Server Base Url
+        /// </summary>
+        string PromactOAuthUrl { get; }
+        /// <summary>
+        /// Promact App Integration Test ClientId
+        /// </summary>
+        string PromactOAuthClientId { get; }
+        /// <summary>
+        /// Promact App Integration Test ClientSecret
+        /// </summary>
+        string PromactOAuthClientSecret { get; }
+        #endregion
     }
 }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/IStringConstant.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/IStringConstant.cs
@@ -89,10 +89,6 @@
         /// </summary>
         string UserIdForTest { get; }
         /// <summary>
-        /// Random slack user Id for test cases
-        /// </summary>
-        string SlackUserIdForTest { get; }
-        /// <summary>
         /// Random slack group name for test
         /// </summary>
         string SlackGroupNameForTest { get; }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/IStringConstant.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/IStringConstant.cs
@@ -5,13 +5,6 @@
     /// </summary>
     public interface IStringConstant
     {
-        #region Base Url
-        /// <summary>
-        /// Promact Oauth server base url
-        /// </summary>
-        string PromactOAuthBaseUrl { get; }
-        #endregion
-
         #region OAUth API Urls
         /// <summary>
         /// Get promact's list of management url

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/StringConstant.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/StringConstant.cs
@@ -320,5 +320,117 @@
             }
         }
         #endregion
+
+        #region Integration Test Cases
+        /// <summary>
+        /// String Id of Admin for Test
+        /// </summary>
+        public string AdminIdForIntegrationTest
+        {
+            get
+            {
+                return "8d29efae-d747-4fc6-a7f1-13f687bd5d67";
+            }
+        }
+
+        /// <summary>
+        /// String Id of User for Test
+        /// </summary>
+        public string UserIdForIntegrationTest
+        {
+            get
+            {
+                return "9cdc7982-25b9-45a4-afdc-6b13e6e53ca6";
+            }
+        }
+
+        /// <summary>
+        /// Random Id for Test cases
+        /// </summary>
+        public string RandomUserIdForTest
+        {
+            get
+            {
+                return "dasfnsjkdnflkasmdlka";
+            }
+        }
+
+        /// <summary>
+        /// String Id of TeamLeader for Test
+        /// </summary>
+        public string TeamLeaderIdForIntegrationTest
+        {
+            get
+            {
+                return "ea18f1db-6fa5-4050-8930-138e0b1ff21d";
+            }
+        }
+
+        /// <summary>
+        /// String Email address of Admin
+        /// </summary>
+        public string AdminEmailForTest
+        {
+            get
+            {
+                return "admin@promactinfo.com";
+            }
+        }
+
+        /// <summary>
+        /// String Project group name for test
+        /// </summary>
+        public string ProjectGroupNameForTest
+        {
+            get
+            {
+                return "Slash-Command";
+            }
+        }
+
+        /// <summary>
+        /// Random Url for test
+        /// </summary>
+        public string RandomUrlForTest
+        {
+            get
+            {
+                return "http://localhost:1234/";
+            }
+        }
+
+        /// <summary>
+        /// Promact Oauth Server Base Url
+        /// </summary>
+        public string PromactOAuthUrl
+        {
+            get
+            {
+                return "http://oauth.promactinfo.com/";
+            }
+        }
+
+        /// <summary>
+        /// Promact App Integration Test ClientId
+        /// </summary>
+        public string PromactOAuthClientId
+        {
+            get
+            {
+                return "OOKK4SVDYQ8XRUU";
+            }
+        }
+
+        /// <summary>
+        /// Promact App Integration Test ClientSecret
+        /// </summary>
+        public string PromactOAuthClientSecret
+        {
+            get
+            {
+                return "icbbHra92LEzIS5AHE6NuuR0Qk20Oo";
+            }
+        }
+        #endregion
     }
 }

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/StringConstant.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/StringConstant.cs
@@ -90,7 +90,7 @@
         {
             get
             {
-                return "api/users/{0}/teammebers";
+                return "api/users/{0}/teammembers";
             }
         }
 
@@ -216,17 +216,6 @@
             get
             {
                 return "7092802a-206e-4ce4-8192-f086a1ec1fb6";
-            }
-        }
-
-        /// <summary>
-        /// Random slack user Id for test cases
-        /// </summary>
-        public string SlackUserIdForTest
-        {
-            get
-            {
-                return "U0HJKJ4";
             }
         }
 

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/StringConstant.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Util/StringConstant/StringConstant.cs
@@ -5,19 +5,6 @@
     /// </summary>
     public class StringConstant : IStringConstant
     {
-        #region Base Url
-        /// <summary>
-        /// Promact Oauth server base url
-        /// </summary>
-        public string PromactOAuthBaseUrl
-        {
-            get
-            {
-                return "http://localhost:35716/";
-            }
-        }
-        #endregion
-
         #region OAUth API Urls
         /// <summary>
         /// Get promact's list of management url


### PR DESCRIPTION
Fixes - #12 & #18 

**1. PromactAuthenticationOptions.cs** - added a new property OpenIdConnectEvents for event
**2. User.cs** - removed slackUserId property
**3. AuthenticationMiddleware.cs** - added event functionality
**4. IUserModule.cs** - updated xml comment
**5. UserModule.cs** - updated xml comment
**6. IStringConstant.cs** - removed SlackUserIdForTest and added new variables -> AdminIdForIntegrationTest, UserIdForIntegrationTest, RandomUserIdForTest, TeamLeaderIdForIntegrationTest, AdminEmailForTest, ProjectGroupNameForTest, RandomUrlForTest, PromactOAuthUrl, PromactOAuthClientId and PromactOAuthClientSecret
**7. StringConstant.cs** - removed SlackUserIdForTest and added new variables -> AdminIdForIntegrationTest, UserIdForIntegrationTest, RandomUserIdForTest, TeamLeaderIdForIntegrationTest, AdminEmailForTest, ProjectGroupNameForTest, RandomUrlForTest, PromactOAuthUrl, PromactOAuthClientId and PromactOAuthClientSecret
**8. IntegrationBaseProvider.cs** - added for integration test cases service
**9. ProjectModuleIntegrationTest.cs** - added integration test cases
**10. ProjectModuleTest.cs** - removed slackUserId Initialization
**11. UserModuleIntegrationTest.cs** - added integration test cases
**12. UserModuleTest.cs** - removed uses of slackUserId
**13. HttpClientService.cs** - used PromactBaseUrl instead of stringconstant url
**14. Project.json** - added package -> "IdentityServer4": "1.1.0"
**15. PromactBaseUrl.cs** - static variable for Promact-OAuth-Base-Url