### PR TITLE
Fixes the Issue of getting claims twice

### DIFF
--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/DomainModel/PromactAuthenticationOptions.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/DomainModel/PromactAuthenticationOptions.cs
@@ -18,6 +18,7 @@ namespace Promact.OAuth.Client.DomainModel
         public PromactAuthenticationOptions()
         {
             AllowedScopes = new List<Scopes>();
+            RequireHttpsMetadata = true;
         }
         /// <summary>
         /// Promact-Oauth's Client Id
@@ -39,6 +40,10 @@ namespace Promact.OAuth.Client.DomainModel
         /// Allowed scope for Promact-Oauth's App
         /// </summary>
         public List<Scopes> AllowedScopes { get; }
+        /// <summary>
+        /// Https is required or not. By default set as true
+        /// </summary>
+        public bool RequireHttpsMetadata { get; set; }
 #if NET461
         /// <summary>
         /// Redirect Url for Promact-Oauth's App

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Middleware/AuthenticationMiddleware.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Middleware/AuthenticationMiddleware.cs
@@ -16,7 +16,7 @@ namespace Promact.OAuth.Client.Middleware
     /// </summary>
     public static class AuthenticationMiddleware
     {
-#if NET461
+#if NET461 
         /// <summary>
         /// Adds the Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationMiddleware
         /// into the OWIN runtime for promact-oauth-server

--- a/Promact.OAuth.Client/src/Promact.OAuth.Client/Middleware/AuthenticationMiddleware.cs
+++ b/Promact.OAuth.Client/src/Promact.OAuth.Client/Middleware/AuthenticationMiddleware.cs
@@ -38,7 +38,6 @@ namespace Promact.OAuth.Client.Middleware
             openIdConnectAuthenticationOptions.SignInAsAuthenticationType = _stringConstant.SignInSchemeCookies;
             openIdConnectAuthenticationOptions.AuthenticationType = _stringConstant.OIDCAuthenticationScheme;
             openIdConnectAuthenticationOptions.PostLogoutRedirectUri = options.LogoutUrl;
-            openIdConnectAuthenticationOptions.UseTokenLifetime = true;
             openIdConnectAuthenticationOptions.Notifications = options.Notifications;
             PromactBaseUrl.PromactOAuthUrl = options.Authority;
             return app.UseOpenIdConnectAuthentication(openIdConnectAuthenticationOptions);
@@ -64,16 +63,11 @@ namespace Promact.OAuth.Client.Middleware
             openIdConnecOptions.AuthenticationScheme = _stringConstant.OIDCAuthenticationScheme;
             openIdConnecOptions.SignInScheme = _stringConstant.SignInSchemeCookies;
             openIdConnecOptions.Authority = options.Authority;
-            openIdConnecOptions.RequireHttpsMetadata = false;
+            openIdConnecOptions.RequireHttpsMetadata = options.RequireHttpsMetadata;
             openIdConnecOptions.ClientId = options.ClientId;
             openIdConnecOptions.ClientSecret = options.ClientSecret;
             openIdConnecOptions.ResponseType = _stringConstant.ResponseTypeCodeAndIdToken;
-            openIdConnecOptions.GetClaimsFromUserInfoEndpoint = true;
-            openIdConnecOptions.SaveTokens = true;
-            openIdConnecOptions.AutomaticAuthenticate = true;
-            openIdConnecOptions.AutomaticChallenge = true;
             openIdConnecOptions.PostLogoutRedirectUri = options.LogoutUrl;
-            openIdConnecOptions.UseTokenLifetime = true;
             PromactBaseUrl.PromactOAuthUrl = options.Authority;
             return app.UseOpenIdConnectAuthentication(openIdConnecOptions);
         }


### PR DESCRIPTION
Fixes - #26 

**1. PromactAuthenticationOptions.cs** - added new property RequireHttpsMetadata and set as true by default
**2. AuthenticationMiddleware.cs** - removed unnecessary intialization in UsePromactAuthentication which return twice claims